### PR TITLE
feat(db): Supabase migrations 001 & 002 — user_profiles and user_dashboard

### DIFF
--- a/voyage-smart-travel/migrations/001_user_profiles.sql
+++ b/voyage-smart-travel/migrations/001_user_profiles.sql
@@ -1,0 +1,141 @@
+-- VST Migration 001 — User Profiles
+-- Run against Supabase project: ovmlmregvcekbvoctywe
+-- Requires: auth.users (Supabase Auth)
+
+-- ── user_profiles ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS user_profiles (
+  id                    uuid        PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  tier                  text        NOT NULL DEFAULT 'GUEST'
+                                    CHECK (tier IN ('GUEST', 'PREMIUM', 'VOYAGE_ELITE')),
+
+  -- Identity
+  full_name             text        NOT NULL DEFAULT '',
+  preferred_name        text        NOT NULL DEFAULT '',
+  avatar_url            text,
+  date_of_birth         date,
+  nationality           char(2),
+  passport_number       text,
+  passport_expiry       date,
+  kyc_status            text        NOT NULL DEFAULT 'NOT_STARTED'
+                                    CHECK (kyc_status IN ('NOT_STARTED', 'PENDING', 'VERIFIED', 'REJECTED')),
+  phone                 text,
+  phone_verified        boolean     NOT NULL DEFAULT false,
+  email_verified        boolean     NOT NULL DEFAULT false,
+
+  -- Preferences
+  locale                text        NOT NULL DEFAULT 'en-GB',
+  timezone              text        NOT NULL DEFAULT 'Europe/London',
+  currency              char(3)     NOT NULL DEFAULT 'GBP',
+  home_airport          char(3),
+  cabin_class           text        NOT NULL DEFAULT 'ECONOMY'
+                                    CHECK (cabin_class IN ('ECONOMY','PREMIUM_ECONOMY','BUSINESS','FIRST')),
+  seat_preference       text        NOT NULL DEFAULT 'NO_PREFERENCE',
+  meal_preference       text        NOT NULL DEFAULT 'STANDARD',
+  loyalty_programs      jsonb       NOT NULL DEFAULT '[]',
+
+  -- Accessibility
+  mobility              text        NOT NULL DEFAULT 'NONE',
+  wheelchair_type       text        NOT NULL DEFAULT 'NOT_APPLICABLE',
+  vision                text        NOT NULL DEFAULT 'NONE',
+  hearing               text        NOT NULL DEFAULT 'NONE',
+  cognitive             boolean     NOT NULL DEFAULT false,
+  dietary_medical       jsonb       NOT NULL DEFAULT '[]',
+  requires_carer        boolean     NOT NULL DEFAULT false,
+  accessibility_notes   text        NOT NULL DEFAULT '',
+
+  -- SOS contacts (up to 5, stored as JSONB array)
+  sos_contacts          jsonb       NOT NULL DEFAULT '[]',
+
+  -- Travel history stats
+  total_trips           int         NOT NULL DEFAULT 0,
+  total_nights          int         NOT NULL DEFAULT 0,
+  countries_visited     jsonb       NOT NULL DEFAULT '[]',
+  total_spend_gbp       numeric(12,2) NOT NULL DEFAULT 0,
+  carbon_kg_total       numeric(10,2) NOT NULL DEFAULT 0,
+  carbon_kg_offset      numeric(10,2) NOT NULL DEFAULT 0,
+  last_trip_at          timestamptz,
+
+  -- Verification
+  email_verified_at     timestamptz,
+  phone_verified_at     timestamptz,
+  kyc_verified_at       timestamptz,
+  kyc_provider          text,
+  two_factor_enabled    boolean     NOT NULL DEFAULT false,
+  two_factor_method     text        NOT NULL DEFAULT 'NONE',
+
+  -- Notification preferences
+  notification_prefs    jsonb       NOT NULL DEFAULT '{
+    "channels":  {"push": true, "in_app": true, "sms": true, "whatsapp": false, "voice": false},
+    "domains":   {"booking": true, "eco": true, "community": true, "pain_guard": true},
+    "quiet_hours": {"enabled": false, "window_start": "22:00", "window_end": "08:00"}
+  }',
+
+  -- GDPR
+  gdpr                  jsonb       NOT NULL DEFAULT '{}',
+
+  -- Pain Guard
+  pain_guard_enrolled       boolean     NOT NULL DEFAULT false,
+  pain_guard_enrolled_at    timestamptz,
+  pain_guard_active_tasks   int         NOT NULL DEFAULT 0,
+  pain_guard_handoff_req    boolean     NOT NULL DEFAULT false,
+
+  -- OneSignal
+  onesignal_player_id   text,
+
+  created_at            timestamptz NOT NULL DEFAULT now(),
+  updated_at            timestamptz NOT NULL DEFAULT now(),
+  last_login_at         timestamptz,
+  deleted_at            timestamptz
+);
+
+-- ── Indexes ───────────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS idx_user_profiles_tier
+  ON user_profiles(tier);
+
+CREATE INDEX IF NOT EXISTS idx_user_profiles_deleted
+  ON user_profiles(deleted_at)
+  WHERE deleted_at IS NULL;
+
+-- ── updated_at trigger ────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_user_profiles_updated_at
+  BEFORE UPDATE ON user_profiles
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- ── Auto-create profile on signup ─────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION handle_new_user()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  INSERT INTO user_profiles (id, full_name, email_verified)
+  VALUES (
+    NEW.id,
+    COALESCE(NEW.raw_user_meta_data->>'full_name', ''),
+    COALESCE(NEW.email_confirmed_at IS NOT NULL, false)
+  )
+  ON CONFLICT (id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE TRIGGER trg_on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION handle_new_user();
+
+-- ── Row Level Security ────────────────────────────────────────────────────────
+ALTER TABLE user_profiles ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "profiles_owner_select" ON user_profiles
+  FOR SELECT USING (auth.uid() = id);
+
+CREATE POLICY "profiles_owner_update" ON user_profiles
+  FOR UPDATE USING (auth.uid() = id);
+
+CREATE POLICY "profiles_service_all" ON user_profiles
+  FOR ALL USING (auth.role() = 'service_role');

--- a/voyage-smart-travel/migrations/002_user_dashboard.sql
+++ b/voyage-smart-travel/migrations/002_user_dashboard.sql
@@ -1,0 +1,112 @@
+-- VST Migration 002 — User Dashboard & Booking History
+-- Run against Supabase project: ovmlmregvcekbvoctywe
+-- Requires: auth.users (Supabase Auth), migration 001 (user_profiles)
+
+-- ── booking_history ───────────────────────────────────────────────────────────
+-- Core booking record — extended by migration 004 (booking_type, provider_ref, details)
+CREATE TABLE IF NOT EXISTS booking_history (
+  booking_id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id             uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  tier                text        NOT NULL DEFAULT 'GUEST',
+  origin              text,
+  destination         text        NOT NULL,
+  departure_date      date        NOT NULL,
+  return_date         date,
+  carrier             text,
+  flight_number       text,
+  price               numeric(10,2) NOT NULL DEFAULT 0,
+  currency            char(3)     NOT NULL DEFAULT 'GBP',
+  status              text        NOT NULL DEFAULT 'PENDING'
+                                  CHECK (status IN ('PENDING', 'CONFIRMED', 'CANCELLED')),
+  confirmation_ref    text        UNIQUE,
+  co2_kg              numeric(10,2),
+  co2_per_person_kg   numeric(10,2),
+  eco_grade           char(1)     CHECK (eco_grade IN ('A','B','C','D','E')),
+  distance_km         numeric(10,2),
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  updated_at          timestamptz NOT NULL DEFAULT now()
+);
+
+-- ── dashboard_widgets ─────────────────────────────────────────────────────────
+-- Per-user widget layout and visibility preferences
+CREATE TABLE IF NOT EXISTS dashboard_widgets (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  widget_key  text        NOT NULL,
+  position    int         NOT NULL DEFAULT 0,
+  visible     boolean     NOT NULL DEFAULT true,
+  config      jsonb       NOT NULL DEFAULT '{}',
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, widget_key)
+);
+
+-- ── eco_milestones ────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS eco_milestones (
+  id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  milestone_key text        NOT NULL,
+  carbon_kg     numeric(10,2) NOT NULL DEFAULT 0,
+  awarded_at    timestamptz NOT NULL DEFAULT now(),
+  notified      boolean     NOT NULL DEFAULT false,
+  UNIQUE (user_id, milestone_key)
+);
+
+-- ── Indexes ───────────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS idx_booking_history_user_created
+  ON booking_history(user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_booking_history_status
+  ON booking_history(user_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_booking_history_departure
+  ON booking_history(user_id, departure_date);
+
+CREATE INDEX IF NOT EXISTS idx_dashboard_widgets_user
+  ON dashboard_widgets(user_id, position);
+
+CREATE INDEX IF NOT EXISTS idx_eco_milestones_user
+  ON eco_milestones(user_id);
+
+-- ── updated_at triggers ───────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_booking_history_updated_at
+  BEFORE UPDATE ON booking_history
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER trg_dashboard_widgets_updated_at
+  BEFORE UPDATE ON dashboard_widgets
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- ── Row Level Security ────────────────────────────────────────────────────────
+ALTER TABLE booking_history    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE dashboard_widgets  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE eco_milestones     ENABLE ROW LEVEL SECURITY;
+
+-- booking_history: owner + service role
+CREATE POLICY "bookings_owner_select" ON booking_history
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "bookings_owner_insert" ON booking_history
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "bookings_service_all" ON booking_history
+  FOR ALL USING (auth.role() = 'service_role');
+
+-- dashboard_widgets: owner only
+CREATE POLICY "widgets_owner" ON dashboard_widgets
+  FOR ALL USING (auth.uid() = user_id);
+
+-- eco_milestones: owner read, service write
+CREATE POLICY "eco_milestones_owner_select" ON eco_milestones
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "eco_milestones_service_all" ON eco_milestones
+  FOR ALL USING (auth.role() = 'service_role');


### PR DESCRIPTION
## Summary

- **001_user_profiles.sql** — creates `user_profiles` table extending `auth.users` with the full VST user model: tier system (GUEST/PREMIUM/VOYAGE_ELITE), identity, preferences, accessibility, SOS contacts, travel history, verification, notification preferences, GDPR object, and Pain Guard fields. Includes an auto-create trigger on `auth.users` INSERT and RLS policies (owner read/update + service_role full access).
- **002_user_dashboard.sql** — creates `booking_history` (required by migration 004's `ALTER TABLE`), `dashboard_widgets`, and `eco_milestones` tables with RLS and indexes.
- Correct run order for all 4 migrations: `001 → 002 → 003 → 004` against Supabase project `ovmlmregvcekbvoctywe`.

## Test plan

- [ ] Apply 001 against Supabase project — confirm `user_profiles` table created, trigger fires on new auth user signup
- [ ] Apply 002 — confirm `booking_history`, `dashboard_widgets`, `eco_milestones` created
- [ ] Apply 003 (`planner_sessions`, `planner_messages`, `planner_itineraries`) — no conflicts
- [ ] Apply 004 (`ALTER TABLE booking_history ADD COLUMN ...`) — confirms 002 ran first
- [ ] Verify RLS: authenticated user can only read/write own rows; service_role bypasses RLS

https://claude.ai/code/session_015tKDgwQumkcP3gwUjrhQHf

---
_Generated by [Claude Code](https://claude.ai/code/session_015tKDgwQumkcP3gwUjrhQHf)_